### PR TITLE
Update diffsitter v0.8.0: remove `git-diffsitter` bin

### DIFF
--- a/diffsitter.rb
+++ b/diffsitter.rb
@@ -19,6 +19,5 @@ class Diffsitter < Formula
 
   def install
     bin.install "diffsitter"
-    bin.install "git-diffsitter"
   end
 end


### PR DESCRIPTION
Hi! It looks like `diffsitter-aarch64-apple-darwin.tar.gz` for v0.8.0 doesn't have a `git-diffsitter` binary, only `diffsitter`. This causes the homebrew formula install to fail:

```
afnanenayet/homebrew-tap $ brew install afnanenayet/tap/diffsitter

==> Fetching afnanenayet/tap/diffsitter
==> Downloading https://github.com/afnanenayet/diffsitter/releases/download/v0.8.0/diffsitter-aarch64-apple-darwin.tar.gz
Already downloaded: /Users/paula1/Library/Caches/Homebrew/downloads/cc8a65cb5f87749cbf24af6649eb83ab0eedd0dc9b1aa57f2f9a30982eaacd06--diffsitter-aarch64-apple-darwin.tar.gz
==> Installing diffsitter from afnanenayet/tap
Error: An exception occurred within a child process:
  Errno::ENOENT: No such file or directory - git-diffsitter
```

Removing `bin.install "git-diffsitter"` lets `brew install` complete as expected.