### PR TITLE
chore: Bump diffsitter formula to v0.8.1

### DIFF
--- a/diffsitter.rb
+++ b/diffsitter.rb
@@ -7,13 +7,13 @@ class Diffsitter < Formula
 
   on_macos do
     on_arm do
-      url "https://github.com/afnanenayet/diffsitter/releases/download/v0.8.0/diffsitter-aarch64-apple-darwin.tar.gz"
-      sha256 "96b5faccfb5a4fc7d8ac27f057f9f9086a59d4ec1f8f5e37368fb303c104cb27"
+      url "https://github.com/afnanenayet/diffsitter/releases/download/v0.8.1/diffsitter-aarch64-apple-darwin.tar.gz"
+      sha256 "c6384fd5d4afd9c2212bc1f89812a926335cd50d47cc8af3e26b30975e072885"
     end
 
     on_intel do
-      url "https://github.com/afnanenayet/diffsitter/releases/download/v0.8.0/diffsitter-x86_64-apple-darwin.tar.gz"
-      sha256 "69e244aa159a11e096901723f8b57aeefa479bafd33c37156e5eb220516567d3"
+      url "https://github.com/afnanenayet/diffsitter/releases/download/v0.8.1/diffsitter-x86_64-apple-darwin.tar.gz"
+      sha256 "5e27db1d6a8acd492b19cdee4cd3be57f7d6c4d6b4db5685c620d1a3e5d8be6b"
     end
   end
 


### PR DESCRIPTION
This should fix an error where the install failed because the
`git-diffsitter` script was missing. That was a bug with the prior
release and the archives should contain the script now.
